### PR TITLE
Changed ScopeGuard interface

### DIFF
--- a/ScopeGuard/src/main/java/info/smart_tools/smartactors/core/scope_guard/IScopeGuard.java
+++ b/ScopeGuard/src/main/java/info/smart_tools/smartactors/core/scope_guard/IScopeGuard.java
@@ -6,20 +6,14 @@ import info.smart_tools.smartactors.core.scope_guard.exception.ScopeGuardExcepti
 /**
  * ScopeGuard interface
  * provides methods for switch current {@link info.smart_tools.smartactors.core.iscope.IScope}
- * by other
- * @since 1.7+
+ * by other.
+ * <p>
+ *     You pass the scope where you want to switch to to the constructor of this object.
+ *     And when the Guard is closed, the initial scope is restored.
+ * </p>
+ * {@link AutoCloseable} requires JRE version 1.7+.
  */
 public interface IScopeGuard extends AutoCloseable {
-
-    /**
-     * Locally save and substitute current instance of {@link info.smart_tools.smartactors.core.iscope.IScope} by
-     * other
-     * @param key unique identifier for find {@link info.smart_tools.smartactors.core.iscope.IScope}
-     * instance in a scope storage
-     * @throws  ScopeGuardException if any errors occurred
-     */
-    void guard(final Object key)
-            throws ScopeGuardException;
 
     /**
      * Set locally saved {@link info.smart_tools.smartactors.core.iscope.IScope} as current

--- a/ScopeGuard/src/main/java/info/smart_tools/smartactors/core/scope_guard/ScopeGuard.java
+++ b/ScopeGuard/src/main/java/info/smart_tools/smartactors/core/scope_guard/ScopeGuard.java
@@ -16,12 +16,12 @@ public class ScopeGuard implements IScopeGuard {
     private IScope previousScope;
 
     /**
-     * Locally save and substitute current instance of {@link IScope} by
+     * Locally saves and substitutes current instance of {@link IScope} by
      * other
      * @param key unique identifier for find {@link IScope}
      * @throws  ScopeGuardException if any errors occurred
      */
-    public void guard(final Object key)
+    public ScopeGuard(final Object key)
             throws ScopeGuardException {
         try {
             previousScope = ScopeProvider.getCurrentScope();
@@ -32,7 +32,7 @@ public class ScopeGuard implements IScopeGuard {
     }
 
     /**
-     * Set locally saved {@link IScope} as current
+     * Sets locally saved {@link IScope} as current
      * @throws ScopeGuardException if any errors occurred
      */
     public void close() throws ScopeGuardException {

--- a/ScopeGuard/src/test/java/info/smart_tools/smartactors/core/scope_guard/ScopeGuardTest.java
+++ b/ScopeGuard/src/test/java/info/smart_tools/smartactors/core/scope_guard/ScopeGuardTest.java
@@ -1,22 +1,12 @@
 package info.smart_tools.smartactors.core.scope_guard;
 
 import info.smart_tools.smartactors.core.iscope.IScope;
-import info.smart_tools.smartactors.core.iscope_provider_container.IScopeProviderContainer;
+import info.smart_tools.smartactors.core.iscope_provider_container.exception.ScopeProviderException;
 import info.smart_tools.smartactors.core.scope_guard.exception.ScopeGuardException;
 import info.smart_tools.smartactors.core.scope_provider.ScopeProvider;
 import org.junit.Test;
 
-import java.lang.reflect.Field;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.fail;
-import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.junit.Assert.*;
 
 /**
  * Tests for ScopeGuard
@@ -32,26 +22,32 @@ public class ScopeGuardTest {
         IScope scope2 = ScopeProvider.getScope(key2);
         assertNotSame(scope1, scope2);
         ScopeProvider.setCurrentScope(scope1);
-        ScopeGuard guard = new ScopeGuard();
-        guard.guard(key2);
+        ScopeGuard guard = new ScopeGuard(key2);
         assertEquals(scope2, ScopeProvider.getCurrentScope());
         guard.close();
+        assertEquals(scope1, ScopeProvider.getCurrentScope());
+    }
+
+    @Test
+    public void checkGuardInResourceTry() throws ScopeProviderException, ScopeGuardException {
+        Object key1 = ScopeProvider.createScope(null);
+        Object key2 = ScopeProvider.createScope(null);
+        IScope scope1 = ScopeProvider.getScope(key1);
+        IScope scope2 = ScopeProvider.getScope(key2);
+        assertNotSame(scope1, scope2);
+        ScopeProvider.setCurrentScope(scope1);
+        try (ScopeGuard guard = new ScopeGuard(key2)) {
+            assertEquals(scope2, ScopeProvider.getCurrentScope());
+        }
         assertEquals(scope1, ScopeProvider.getCurrentScope());
     }
 
     @Test (expected = ScopeGuardException.class)
     public void checkScopeGuardExceptionOnGuard()
             throws Exception {
-        ScopeGuard guard = new ScopeGuard();
         Object key = new Object();
-        guard.guard(key);
+        ScopeGuard guard = new ScopeGuard(key);
         fail();
     }
 
-    @Test (expected = ScopeGuardException.class)
-    public void checkScopeGuardExceptionOnClose() throws ScopeGuardException {
-        ScopeGuard guard = new ScopeGuard();
-        guard.close();
-        fail();
-    }
 }


### PR DESCRIPTION
Changed ScopeGuard interface and implementation to avoid useless Guard without the Scope defined and allow easier usage with resource-try.
