### PR TITLE
Add base class for plugins registering bootstrap items.

### DIFF
--- a/BootstrapPlugin/pom.xml
+++ b/BootstrapPlugin/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>core</artifactId>
+        <groupId>info.smart_tools.smartactors</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>plugin.base.bootstrap_plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>core.ibootstrap</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>core.bootstrap_item</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>core.iplugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/BootstrapPlugin.java
+++ b/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/BootstrapPlugin.java
@@ -1,0 +1,124 @@
+package info.smart_tools.smartactors.plugin.base.bootstrap_plugin;
+
+import info.smart_tools.smartactors.core.ibootstrap.IBootstrap;
+import info.smart_tools.smartactors.core.ibootstrap_item.IBootstrapItem;
+import info.smart_tools.smartactors.core.invalid_argument_exception.InvalidArgumentException;
+import info.smart_tools.smartactors.core.iplugin.IPlugin;
+import info.smart_tools.smartactors.core.iplugin.exception.PluginException;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import java.lang.reflect.Method;
+
+/**
+ * Base class for {@link IPlugin plugins} registering {@link IBootstrapItem bootstrap items} in a {@link IBootstrap bootstrap} passed to
+ * constructor.
+ *
+ * <p>
+ *     Example of a plugin:
+ * </p>
+ *
+ * <pre>
+ *     public class MyPlugin extends BootstrapPlugin {
+ *         public MyPlugin(final IBootstrap bs) {
+ *             super(bs);
+ *         }
+ *
+ *         {@literal @}Item("my_item_1")                        // Name of the item
+ *         {@literal @}After({"other_item_1", "other_item_2")   // Names of items to execute after which
+ *         {@literal @}Before({"one_more_item"})                // Names of the items to execute before which
+ *         public void myItem1()
+ *                 throws SomeException {
+ *             // . . . Body of the item
+ *         }
+ *
+ *         {@literal @}Item("my_item_2")                        // {@literal @}After and {@literal @}Before annotations are optional
+ *         public void myItem2() {
+ *             // . . .
+ *         }
+ *     }
+ * </pre>
+ */
+public abstract class BootstrapPlugin implements IPlugin {
+    /**
+     * Annotation used to mark the methods of plugins extending {@link BootstrapPlugin} for which the bootstrap items should e created.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Item {
+        /**
+         * Name of the bootstrap item to create.
+         *
+         * @return name of bootstrap item
+         */
+        String value();
+    }
+
+    /**
+     * Annotation storing array of names of bootstrap items that should be executed before the item created for annotated method.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface After {
+        /**
+         * Array of names of items after which the item should be executed.
+         *
+         * @return array of item names
+         */
+        String[] value();
+    }
+
+    /**
+     * Annotation storing array of names of bootstrap items that should be executed after the item created for annotated method.
+     */
+    @Target(ElementType.METHOD)
+    @Retention(RetentionPolicy.RUNTIME)
+    public @interface Before {
+        /**
+         * Array of names of items before which the item should be executed.
+         *
+         * @return array of item names
+         */
+        String[] value();
+    }
+
+    private IBootstrap<IBootstrapItem<String>> bootstrap;
+
+    /**
+     * The constructor.
+     *
+     * <p>
+     *     Constructor of a plugin extending this class should look like the following:
+     * </p>
+     *
+     * <pre>
+     *     class MyPlugin extends BootstrapPlugin {
+     *         public MyPlugin(final IBootstrap bs) {
+     *             super(bs);
+     *         }
+     *     }
+     * </pre>
+     *
+     * @param bootstrap    the bootstrap
+     */
+    protected BootstrapPlugin(final IBootstrap bootstrap) {
+        this.bootstrap = bootstrap;
+    }
+
+    @Override
+    public final void load() throws PluginException {
+        try {
+            for (Method method : this.getClass().getMethods()) {
+                if (null == method.getAnnotation(Item.class)) {
+                    continue;
+                }
+
+                bootstrap.add(new MethodBootstrapItem(this, method));
+            }
+        } catch (InvalidArgumentException e) {
+            throw new PluginException(e);
+        }
+    }
+}

--- a/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/MethodBootstrapItem.java
+++ b/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/MethodBootstrapItem.java
@@ -1,0 +1,61 @@
+package info.smart_tools.smartactors.plugin.base.bootstrap_plugin;
+
+import info.smart_tools.smartactors.core.bootstrap_item.BootstrapItem;
+import info.smart_tools.smartactors.core.iaction.exception.ActionExecuteException;
+import info.smart_tools.smartactors.core.invalid_argument_exception.InvalidArgumentException;
+import info.smart_tools.smartactors.core.iplugin.IPlugin;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.text.MessageFormat;
+
+/**
+ * Bootstrap item created from a plugin method.
+ */
+class MethodBootstrapItem extends BootstrapItem {
+
+    /**
+     * The constructor.
+     *
+     * @param plugin    the plugin instance
+     * @param method    the method annotated with {@link BootstrapPlugin.Item}
+     * @throws InvalidArgumentException if item name is {@code null}
+     */
+    MethodBootstrapItem(final IPlugin plugin, final Method method)
+            throws InvalidArgumentException {
+        super(method.getAnnotation(BootstrapPlugin.Item.class).value());
+
+        if (method.getParameterCount() != 0) {
+            throw new InvalidArgumentException(
+                    MessageFormat.format(
+                            "Bootstrap item body method should have no parameters but method {0} of {1} (item ''{2}'') has some.",
+                            method.getName(),
+                            method.getDeclaringClass().getName(),
+                            method.getAnnotation(BootstrapPlugin.Item.class).value()));
+        }
+
+        BootstrapPlugin.After after = method.getAnnotation(BootstrapPlugin.After.class);
+
+        if (null != after) {
+            for (String name : after.value()) {
+                this.after(name);
+            }
+        }
+
+        BootstrapPlugin.Before before = method.getAnnotation(BootstrapPlugin.Before.class);
+
+        if (null != before) {
+            for (String name : before.value()) {
+                this.before(name);
+            }
+        }
+
+        this.process(() -> {
+            try {
+                method.invoke(plugin);
+            } catch (InvocationTargetException | IllegalAccessException e) {
+                throw new ActionExecuteException(e);
+            }
+        });
+    }
+}

--- a/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/package-info.java
+++ b/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contains base class for plugins registering bootstrap items in a bootstrap.
+ */
+package info.smart_tools.smartactors.plugin.base.bootstrap_plugin;

--- a/BootstrapPlugin/src/test/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/BootstrapPluginTest.java
+++ b/BootstrapPlugin/src/test/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/BootstrapPluginTest.java
@@ -1,0 +1,64 @@
+package info.smart_tools.smartactors.plugin.base.bootstrap_plugin;
+
+import info.smart_tools.smartactors.core.ibootstrap.IBootstrap;
+import info.smart_tools.smartactors.core.ibootstrap_item.IBootstrapItem;
+import info.smart_tools.smartactors.core.iplugin.IPlugin;
+import info.smart_tools.smartactors.core.iplugin.exception.PluginException;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for {@link BootstrapPlugin}.
+ */
+public class BootstrapPluginTest {
+    private IBootstrap bootstrapMock;
+    private ArgumentCaptor<IBootstrapItem> itemArgumentCaptor;
+
+    @Before
+    public void setUp()
+            throws Exception {
+        bootstrapMock = mock(IBootstrap.class);
+        itemArgumentCaptor = ArgumentCaptor.forClass(IBootstrapItem.class);
+    }
+
+    @Test(expected = PluginException.class)
+    public void Should_throwWhenPluginContainsInvalidMethods()
+            throws Exception {
+        IPlugin plugin = new BootstrapPlugin(bootstrapMock) {
+            @BootstrapPlugin.Item("wrongItem")
+            public void wrongItemMethod(int x) {}
+        };
+
+        plugin.load();
+    }
+
+    @Test
+    public void Should_createItemsForAnnotatedMethods()
+            throws Exception {
+        IPlugin plugin = new BootstrapPlugin(bootstrapMock) {
+            @BootstrapPlugin.Item("item1")
+            public void item1Method() {
+            }
+
+            @BootstrapPlugin.Item("item2")
+            public void item2Method() {
+            }
+
+            public void notItemMethod() {}
+        };
+
+        plugin.load();
+
+        verify(bootstrapMock, times(2)).add(itemArgumentCaptor.capture());
+
+        for (IBootstrapItem item : itemArgumentCaptor.getAllValues()) {
+            assertTrue(item instanceof MethodBootstrapItem);
+        }
+    }
+}

--- a/BootstrapPlugin/src/test/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/MethodBootstrapItemTest.java
+++ b/BootstrapPlugin/src/test/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/MethodBootstrapItemTest.java
@@ -1,0 +1,87 @@
+package info.smart_tools.smartactors.plugin.base.bootstrap_plugin;
+
+import info.smart_tools.smartactors.core.iaction.IAction;
+import info.smart_tools.smartactors.core.iaction.exception.ActionExecuteException;
+import info.smart_tools.smartactors.core.ibootstrap_item.exception.ProcessExecutionException;
+import info.smart_tools.smartactors.core.invalid_argument_exception.InvalidArgumentException;
+import info.smart_tools.smartactors.core.iplugin.IPlugin;
+import info.smart_tools.smartactors.core.iplugin.exception.PluginException;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * Test for {@link MethodBootstrapItem}.
+ */
+public class MethodBootstrapItemTest {
+    @Test
+    public void Should_readAnnotationsAndInvokeMethod()
+            throws Exception {
+        IAction<IPlugin> actionMock = mock(IAction.class);
+        IPlugin plugin = new IPlugin() {
+            @Override
+            public void load() throws PluginException {
+                //
+            }
+
+            @BootstrapPlugin.Item("theItem")
+            @BootstrapPlugin.After({"aItem1", "aItem2"})
+            @BootstrapPlugin.Before({"bItem1", "bItem2"})
+            public void methodOfTheItem()
+                    throws ActionExecuteException, InvalidArgumentException {
+                actionMock.execute(this);
+            }
+        };
+
+        MethodBootstrapItem item = new MethodBootstrapItem(plugin, plugin.getClass().getMethod("methodOfTheItem"));
+
+        assertEquals("theItem", item.getItemName());
+        assertEquals(Arrays.asList("aItem1", "aItem2"), item.getAfterItems());
+        assertEquals(Arrays.asList("bItem1", "bItem2"), item.getBeforeItems());
+
+        verify(actionMock, times(0)).execute(same(plugin));
+        item.executeProcess();
+        verify(actionMock, times(1)).execute(same(plugin));
+    }
+
+    @Test(expected = InvalidArgumentException.class)
+    public void Should_throwWhenMethodHasParameters()
+            throws Exception {
+        IPlugin plugin = new IPlugin() {
+            @Override
+            public void load() throws PluginException {
+                //
+            }
+
+            @BootstrapPlugin.Item("theItem")
+            public void methodOfTheItem(Object par1) {
+            }
+        };
+
+        assertNotNull(new MethodBootstrapItem(plugin, plugin.getClass().getMethod("methodOfTheItem", Object.class)));
+    }
+
+    @Test(expected = ProcessExecutionException.class)
+    public void Should_wrapExceptionThrownByItemBody()
+            throws Exception {
+        IPlugin plugin = new IPlugin() {
+            @Override
+            public void load() throws PluginException {
+                //
+            }
+
+            @BootstrapPlugin.Item("theItem")
+            public void methodOfTheItem() {
+                throw new RuntimeException();
+            }
+        };
+
+        new MethodBootstrapItem(plugin, plugin.getClass().getMethod("methodOfTheItem")).executeProcess();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -297,6 +297,7 @@
         <module>IAdditionDependencyStrategy</module>
         <module>RepeaterActor</module>
         <module>PluginRepeaterActor</module>
+        <module>BootstrapPlugin</module>
     </modules>
 
     <build>


### PR DESCRIPTION
Added more simple way to create plugins registering bootstrap items in a bootstrap. For example see [javadoc of BootstrapPlugin](https://github.com/SmartTools/smartactors-core/blob/d97735bc9251115b76be7da9392117a8ec3f9938/BootstrapPlugin/src/main/java/info/smart_tools/smartactors/plugin/base/bootstrap_plugin/BootstrapPlugin.java#L24).
