### PR TITLE
Add constant chain choice strategy.

### DIFF
--- a/CoreFeaturePlugins/MessageProcessing-plugins/PluginConstantChainChoiceStrategy/pom.xml
+++ b/CoreFeaturePlugins/MessageProcessing-plugins/PluginConstantChainChoiceStrategy/pom.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>message-processing-plugins</artifactId>
+        <groupId>info.smart_tools.smartactors</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>message-procesing-plugins.constant-chain-choice-strategy-plugin</artifactId>
+
+    <dependencies>
+        <!-- Core interfaces -->
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>feature-loading-system.interfaces.iplugin</artifactId>
+            <version>${core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>feature-loading-system.interfaces.ibootstrap</artifactId>
+            <version>${core.version}</version>
+        </dependency>
+
+        <!-- Base plugin class -->
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>feature-loading-system.bootstrap-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Implementation to register -->
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>message-processing.constant-chain-choice-strategy</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Strategy -->
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>base.strategy.singleton-strategy</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/CoreFeaturePlugins/MessageProcessing-plugins/PluginConstantChainChoiceStrategy/src/main/java/info/smart_tools/smartactors/message_procesing_plugins/constant_chain_choice_strategy_plugin/PluginConstantChainChoiceStrategy.java
+++ b/CoreFeaturePlugins/MessageProcessing-plugins/PluginConstantChainChoiceStrategy/src/main/java/info/smart_tools/smartactors/message_procesing_plugins/constant_chain_choice_strategy_plugin/PluginConstantChainChoiceStrategy.java
@@ -1,0 +1,35 @@
+package info.smart_tools.smartactors.message_procesing_plugins.constant_chain_choice_strategy_plugin;
+
+import info.smart_tools.smartactors.base.exception.invalid_argument_exception.InvalidArgumentException;
+import info.smart_tools.smartactors.base.strategy.singleton_strategy.SingletonStrategy;
+import info.smart_tools.smartactors.feature_loading_system.bootstrap_plugin.BootstrapPlugin;
+import info.smart_tools.smartactors.feature_loading_system.interfaces.ibootstrap.IBootstrap;
+import info.smart_tools.smartactors.ioc.iioccontainer.exception.RegistrationException;
+import info.smart_tools.smartactors.ioc.iioccontainer.exception.ResolutionException;
+import info.smart_tools.smartactors.ioc.ioc.IOC;
+import info.smart_tools.smartactors.ioc.named_keys_storage.Keys;
+import info.smart_tools.smartactors.message_processing.constant_chain_choice_strategy.ConstantChainChoiceStrategy;
+
+/**
+ * Plugin that registers constant chain choice strategy.
+ */
+public class PluginConstantChainChoiceStrategy extends BootstrapPlugin {
+    protected PluginConstantChainChoiceStrategy(IBootstrap bootstrap) {
+        super(bootstrap);
+    }
+
+    /**
+     * Register constant chain choice strategy as a singleton.
+     *
+     * @throws ResolutionException if error occurs resoling key or dependencies of chain choice strategy
+     * @throws RegistrationException if error occurs registering the strategy
+     * @throws InvalidArgumentException if {@link SingletonStrategy} doesn't like our arguments
+     */
+    @Item("constant_chain_choice_strategy")
+    @After({"IOC"})
+    @Before({"ChainCallReceiver"})
+    public void item()
+            throws ResolutionException, RegistrationException, InvalidArgumentException {
+        IOC.register(Keys.getOrAdd("constant chain choice strategy"), new SingletonStrategy(new ConstantChainChoiceStrategy()));
+    }
+}

--- a/CoreFeaturePlugins/MessageProcessing-plugins/pom.xml
+++ b/CoreFeaturePlugins/MessageProcessing-plugins/pom.xml
@@ -31,6 +31,7 @@
         <module>PluginWrapperGenerator</module>
         <module>PluginStarter</module>
         <module>PluginStandardObjectCreators</module>
+        <module>PluginConstantChainChoiceStrategy</module>
     </modules>
 
     <repositories>

--- a/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/pom.xml
+++ b/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>message-processing</artifactId>
+        <groupId>info.smart_tools.smartactors</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>message-processing.constant-chain-choice-strategy</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>message-processing-interfaces.message-processing</artifactId>
+            <version>${core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>message-processing-interfaces.ichain-storage</artifactId>
+            <version>${core.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>base.exception.invalid-argument-exception</artifactId>
+            <version>${core.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>message-processing.chain-call-receiver</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>ioc.ioc</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>ioc.named-keys-storage</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <!-- Tests -->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+            <version>1.10.19</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>helpers.plugins-loading-test-base</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Test plugins -->
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>scope-plugins.scoped-ioc-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>ioc-plugins.ioc-keys-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>scope-plugins.scope-provider-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>iobject-plugins.fieldname-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>iobject-plugins.ds-object-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>iobject-plugins.ifieldname-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/src/main/java/info/smart_tools/smartactors/message_processing/constant_chain_choice_strategy/ConstantChainChoiceStrategy.java
+++ b/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/src/main/java/info/smart_tools/smartactors/message_processing/constant_chain_choice_strategy/ConstantChainChoiceStrategy.java
@@ -1,0 +1,31 @@
+package info.smart_tools.smartactors.message_processing.constant_chain_choice_strategy;
+
+import info.smart_tools.smartactors.iobject.ifield_name.IFieldName;
+import info.smart_tools.smartactors.ioc.iioccontainer.exception.ResolutionException;
+import info.smart_tools.smartactors.ioc.ioc.IOC;
+import info.smart_tools.smartactors.ioc.named_keys_storage.Keys;
+import info.smart_tools.smartactors.message_processing.chain_call_receiver.IChainChoiceStrategy;
+import info.smart_tools.smartactors.message_processing.chain_call_receiver.exceptions.ChainChoiceException;
+import info.smart_tools.smartactors.message_processing_interfaces.message_processing.IMessageProcessor;
+
+/**
+ * {@link IChainChoiceStrategy Chain choice strategy} that always returns the same chain id for the same step.
+ */
+public class ConstantChainChoiceStrategy implements IChainChoiceStrategy {
+    private final IFieldName chainIdFieldName;
+
+    public ConstantChainChoiceStrategy()
+            throws ResolutionException {
+        chainIdFieldName = IOC.resolve(Keys.getOrAdd(IFieldName.class.getCanonicalName()), "chain");
+    }
+
+    @Override
+    public Object chooseChain(IMessageProcessor messageProcessor) throws ChainChoiceException {
+        try {
+            Object name = messageProcessor.getSequence().getCurrentReceiverArguments().getValue(chainIdFieldName);
+            return IOC.resolve(Keys.getOrAdd("chain_id_from_map_name"), name);
+        } catch (Exception e) {
+            throw new ChainChoiceException("Exception occurred reading chain id for current step.", e);
+        }
+    }
+}

--- a/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/src/test/java/info/smart_tools/smartactors/message_processing/constant_chain_choice_strategy/ConstantChainChoiceStrategyTest.java
+++ b/CoreFeatures/MessageProcessing/ConstantChainChoiceStrategy/src/test/java/info/smart_tools/smartactors/message_processing/constant_chain_choice_strategy/ConstantChainChoiceStrategyTest.java
@@ -1,0 +1,78 @@
+package info.smart_tools.smartactors.message_processing.constant_chain_choice_strategy;
+
+import info.smart_tools.smartactors.base.interfaces.iresolve_dependency_strategy.IResolveDependencyStrategy;
+import info.smart_tools.smartactors.base.interfaces.iresolve_dependency_strategy.exception.ResolveDependencyStrategyException;
+import info.smart_tools.smartactors.helpers.plugins_loading_test_base.PluginsLoadingTestBase;
+import info.smart_tools.smartactors.iobject.iobject.IObject;
+import info.smart_tools.smartactors.iobject_plugins.dsobject_plugin.PluginDSObject;
+import info.smart_tools.smartactors.iobject_plugins.ifieldname_plugin.IFieldNamePlugin;
+import info.smart_tools.smartactors.ioc.ioc.IOC;
+import info.smart_tools.smartactors.ioc.named_keys_storage.Keys;
+import info.smart_tools.smartactors.ioc_plugins.ioc_keys_plugin.PluginIOCKeys;
+import info.smart_tools.smartactors.message_processing.chain_call_receiver.IChainChoiceStrategy;
+import info.smart_tools.smartactors.message_processing.chain_call_receiver.exceptions.ChainChoiceException;
+import info.smart_tools.smartactors.message_processing_interfaces.message_processing.IMessageProcessingSequence;
+import info.smart_tools.smartactors.message_processing_interfaces.message_processing.IMessageProcessor;
+import info.smart_tools.smartactors.scope_plugins.scope_provider_plugin.PluginScopeProvider;
+import info.smart_tools.smartactors.scope_plugins.scoped_ioc_plugin.ScopedIOCPlugin;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Test for {@link ConstantChainChoiceStrategy}.
+ */
+public class ConstantChainChoiceStrategyTest extends PluginsLoadingTestBase {
+    private IResolveDependencyStrategy chainIdStrategy;
+    private IMessageProcessor messageProcessorMock;
+    private Object id = new Object();
+
+    @Override
+    protected void loadPlugins()
+            throws Exception {
+        load(ScopedIOCPlugin.class);
+        load(PluginScopeProvider.class);
+        load(PluginIOCKeys.class);
+        load(PluginDSObject.class);
+        load(IFieldNamePlugin.class);
+    }
+
+
+    @Override
+    protected void registerMocks()
+            throws Exception {
+        chainIdStrategy = mock(IResolveDependencyStrategy.class);
+        messageProcessorMock = mock(IMessageProcessor.class);
+        IMessageProcessingSequence messageProcessingSequenceMock = mock(IMessageProcessingSequence.class);
+        IObject args = IOC.resolve(Keys.getOrAdd(IObject.class.getCanonicalName()), "{'chain':'chain_to_call_name'}".replace('\'', '"'));
+
+        when(messageProcessorMock.getSequence()).thenReturn(messageProcessingSequenceMock);
+        when(messageProcessingSequenceMock.getCurrentReceiverArguments()).thenReturn(args);
+        when(chainIdStrategy.resolve(eq("chain_to_call_name"))).thenReturn(id);
+
+
+        IOC.register(Keys.getOrAdd("chain_id_from_map_name"), chainIdStrategy);
+    }
+
+    @Test
+    public void Should_chooseChainUsingIdentifierInCurrentStepArguments()
+            throws Exception {
+        IChainChoiceStrategy strategy = new ConstantChainChoiceStrategy();
+
+        assertSame(id, strategy.chooseChain(messageProcessorMock));
+    }
+
+    @Test(expected = ChainChoiceException.class)
+    public void Should_wrapExceptionThrownByIOC()
+            throws Exception {
+        when(chainIdStrategy.resolve(any())).thenThrow(ResolveDependencyStrategyException.class);
+
+        IChainChoiceStrategy strategy = new ConstantChainChoiceStrategy();
+
+        strategy.chooseChain(messageProcessorMock);
+    }
+}

--- a/CoreFeatures/MessageProcessing/pom.xml
+++ b/CoreFeatures/MessageProcessing/pom.xml
@@ -31,6 +31,7 @@
         <module>ReceiverChain</module>
         <module>ReceiverGenerator</module>
         <module>WrapperGenerator</module>
+        <module>ConstantChainChoiceStrategy</module>
     </modules>
 
     <repositories>


### PR DESCRIPTION
Add a strategy for `ChainCallReceiver` that will call a chain specified in step description.

Example:

Receiver configuration (in `"objects"` section):

```
{
  "name": "call_this_chain_receiver",
  "kind": "raw",
  "dependency": "info.smart_tools.smartactors.message_processing.chain_call_receiver.ChainCallReceiver",
  "strategyDependency": "constant chain choice strategy"
}
```

Chain step that always calls chain named `"myChain"`:

```
{
  "target": "call_this_chain_receiver",
  "chain": "myChain"
}
```
