### PR TITLE
Add stub checkpoint.

### DIFF
--- a/CoreFeaturePlugins/Checkpoint-plugins/CheckpointActorPlugin/pom.xml
+++ b/CoreFeaturePlugins/Checkpoint-plugins/CheckpointActorPlugin/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>checkpoint-plugins</artifactId>
+        <groupId>info.smart_tools.smartactors</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>checkpoint-plugins.checkpoint-actor-plugin</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>feature-loading-system.bootstrap-plugin</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>ioc.ioc</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>ioc.named-keys-storage</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>base.strategy.apply-function-to-arguments</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>checkpoint.checkpoint-actor</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/CoreFeaturePlugins/Checkpoint-plugins/CheckpointActorPlugin/src/main/java/info/smart_tools/smartactors/checkpoint_plugins/checkpoint_actor_plugin/CheckpointActorPlugin.java
+++ b/CoreFeaturePlugins/Checkpoint-plugins/CheckpointActorPlugin/src/main/java/info/smart_tools/smartactors/checkpoint_plugins/checkpoint_actor_plugin/CheckpointActorPlugin.java
@@ -1,0 +1,61 @@
+package info.smart_tools.smartactors.checkpoint_plugins.checkpoint_actor_plugin;
+
+import info.smart_tools.smartactors.base.exception.invalid_argument_exception.InvalidArgumentException;
+import info.smart_tools.smartactors.base.interfaces.iaction.exception.FunctionExecutionException;
+import info.smart_tools.smartactors.base.strategy.apply_function_to_arguments.ApplyFunctionToArgumentsStrategy;
+import info.smart_tools.smartactors.checkpoint.checkpoint_actor.CheckpointActor;
+import info.smart_tools.smartactors.feature_loading_system.bootstrap_plugin.BootstrapPlugin;
+import info.smart_tools.smartactors.feature_loading_system.interfaces.ibootstrap.IBootstrap;
+import info.smart_tools.smartactors.iobject.ifield_name.IFieldName;
+import info.smart_tools.smartactors.iobject.iobject.IObject;
+import info.smart_tools.smartactors.ioc.iioccontainer.exception.RegistrationException;
+import info.smart_tools.smartactors.ioc.iioccontainer.exception.ResolutionException;
+import info.smart_tools.smartactors.ioc.ioc.IOC;
+import info.smart_tools.smartactors.ioc.named_keys_storage.Keys;
+
+/**
+ * Plugin that registers stub checkpoint actor dependency.
+ *
+ * TODO: Implement real actor and plugin.
+ */
+public class CheckpointActorPlugin extends BootstrapPlugin {
+    /**
+     * The constructor.
+     *
+     * @param bootstrap    the bootstrap
+     */
+    public CheckpointActorPlugin(final IBootstrap bootstrap) {
+        super(bootstrap);
+    }
+
+    /**
+     * Register the checkpoint actor.
+     *
+     * @throws ResolutionException
+     * @throws RegistrationException
+     * @throws InvalidArgumentException
+     */
+    @Item("checkpoint_actor")
+    public void registerCheckpointActorStub()
+            throws ResolutionException, RegistrationException, InvalidArgumentException {
+        IOC.register(Keys.getOrAdd("checkpoint actor"), new ApplyFunctionToArgumentsStrategy(a -> {
+            try {
+                IObject args = (IObject) a[0];
+
+                IFieldName connectionOptionsFN = IOC.resolve(Keys.getOrAdd(IFieldName.class.getCanonicalName()), "connectionOptionsDependency");
+                IFieldName connectionPoolFN = IOC.resolve(Keys.getOrAdd(IFieldName.class.getCanonicalName()), "connectionPoolDependency");
+                IFieldName collectionNameFN = IOC.resolve(Keys.getOrAdd(IFieldName.class.getCanonicalName()), "collectionName");
+
+                if (!(args.getValue(collectionNameFN) instanceof String) ||
+                        !(args.getValue(connectionPoolFN) instanceof String) ||
+                        !(args.getValue(connectionOptionsFN) instanceof String)) {
+                    throw new InvalidArgumentException("Invalid checkpoint actor configuration.");
+                }
+
+                return new CheckpointActor();
+            } catch (Exception e) {
+                throw new FunctionExecutionException(e);
+            }
+        }));
+    }
+}

--- a/CoreFeaturePlugins/Checkpoint-plugins/bin.xml
+++ b/CoreFeaturePlugins/Checkpoint-plugins/bin.xml
@@ -1,0 +1,28 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>archive</id>
+    <formats>
+        <format>zip</format>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <moduleSets>
+        <moduleSet>
+            <binaries>
+                <outputDirectory>/</outputDirectory>
+                <unpack>false</unpack>
+            </binaries>
+        </moduleSet>
+    </moduleSets>
+    <fileSets>
+        <fileSet>
+            <includes>
+                <include>config.json</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>
+

--- a/CoreFeaturePlugins/Checkpoint-plugins/config.json
+++ b/CoreFeaturePlugins/Checkpoint-plugins/config.json
@@ -1,0 +1,16 @@
+{
+  "featureName": "checkpoint-plugins",
+  "afterFeatures": ["checkpoint"],
+
+  "objects_example": [
+    {
+      "name": "checkpoint",
+      "kind": "stateless_actor",
+      "dependency": "checkpoint actor",
+
+      "connectionOptionsDependency": "checkpoint connection options",
+      "connectionPoolDependency": "checkpoint connection pool",
+      "collectionName": "checkpoint_collection"
+    }
+  ]
+}

--- a/CoreFeaturePlugins/Checkpoint-plugins/pom.xml
+++ b/CoreFeaturePlugins/Checkpoint-plugins/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
+
+    <groupId>info.smart_tools.smartactors</groupId>
+    <artifactId>checkpoint-plugins</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <core.version>0.2.0-SNAPSHOT</core.version>
+        <feature.version>0.2.0-SNAPSHOT</feature.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>CheckpointActorPlugin</module>
+    </modules>
+
+    <repositories>
+        <repository>
+            <id>archiva.smartactors-modules</id>
+            <url>http://archiva.smart-tools.info/repository/smartactors-modules/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <descriptor>bin.xml</descriptor>
+                    <finalName>${artifactId}-${pom.version}</finalName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <goals>
+                    <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                    <generatePom>false</generatePom>
+                    <file>${basedir}/target/${artifactId}-${feature.version}-archive.zip</file>
+                    <url>http://archiva.smart-tools.info/repository/smartactors-features/</url>
+                    <repositoryId>archiva.smartactors-features</repositoryId>
+
+                    <groupId>info.smart_tools.smartactors</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${feature.version}</version>
+                    <packaging>zip</packaging>
+                    <description>The artifact contains follow list of modules: </description>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <distributionManagement>
+        <repository>
+            <id>archiva.smartactors-modules</id>
+            <url>http://archiva.smart-tools.info/repository/smartactors-modules/</url>
+        </repository>
+    </distributionManagement>
+
+</project>

--- a/CoreFeatures/Checkpoint/CheckpointActor/pom.xml
+++ b/CoreFeatures/Checkpoint/CheckpointActor/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>checkpoint</artifactId>
+        <groupId>info.smart_tools.smartactors</groupId>
+        <version>0.2.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>checkpoint.checkpoint-actor</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>iobject.iobject</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+
+        <dependency>
+            <groupId>info.smart_tools.smartactors</groupId>
+            <artifactId>message-processing-interfaces.message-processing</artifactId>
+            <version>0.2.0-SNAPSHOT</version>
+        </dependency>
+    </dependencies>
+</project>

--- a/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/CheckpointActor.java
+++ b/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/CheckpointActor.java
@@ -1,0 +1,17 @@
+package info.smart_tools.smartactors.checkpoint.checkpoint_actor;
+
+import info.smart_tools.smartactors.checkpoint.checkpoint_actor.wrappers.EnteringMessage;
+import info.smart_tools.smartactors.checkpoint.checkpoint_actor.wrappers.FeedbackMessage;
+
+/**
+ * Stub checkpoint actor.
+ */
+public class CheckpointActor {
+    public void enter(final EnteringMessage message) {
+
+    }
+
+    public void feedback(final FeedbackMessage message) {
+
+    }
+}

--- a/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/wrappers/EnteringMessage.java
+++ b/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/wrappers/EnteringMessage.java
@@ -1,0 +1,11 @@
+package info.smart_tools.smartactors.checkpoint.checkpoint_actor.wrappers;
+
+import info.smart_tools.smartactors.iobject.iobject.exception.ReadValueException;
+import info.smart_tools.smartactors.message_processing_interfaces.message_processing.IMessageProcessor;
+
+/**
+ *
+ */
+public interface EnteringMessage {
+    IMessageProcessor getProcessor() throws ReadValueException;
+}

--- a/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/wrappers/FeedbackMessage.java
+++ b/CoreFeatures/Checkpoint/CheckpointActor/src/main/java/info/smart_tools/smartactors/checkpoint/checkpoint_actor/wrappers/FeedbackMessage.java
@@ -1,0 +1,7 @@
+package info.smart_tools.smartactors.checkpoint.checkpoint_actor.wrappers;
+
+/**
+ *
+ */
+public interface FeedbackMessage {
+}

--- a/CoreFeatures/Checkpoint/bin.xml
+++ b/CoreFeatures/Checkpoint/bin.xml
@@ -1,0 +1,28 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <id>archive</id>
+    <formats>
+        <format>zip</format>
+        <format>jar</format>
+    </formats>
+
+    <includeBaseDirectory>true</includeBaseDirectory>
+
+    <moduleSets>
+        <moduleSet>
+            <binaries>
+                <outputDirectory>/</outputDirectory>
+                <unpack>false</unpack>
+            </binaries>
+        </moduleSet>
+    </moduleSets>
+    <fileSets>
+        <fileSet>
+            <includes>
+                <include>config.json</include>
+            </includes>
+        </fileSet>
+    </fileSets>
+</assembly>
+

--- a/CoreFeatures/Checkpoint/config.json
+++ b/CoreFeatures/Checkpoint/config.json
@@ -1,0 +1,4 @@
+{
+  "featureName": "checkpoint",
+  "afterFeatures": []
+}

--- a/CoreFeatures/Checkpoint/pom.xml
+++ b/CoreFeatures/Checkpoint/pom.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<modelVersion>4.0.0</modelVersion>
+
+    <groupId>info.smart_tools.smartactors</groupId>
+    <artifactId>checkpoint</artifactId>
+    <version>0.2.0-SNAPSHOT</version>
+
+    <packaging>pom</packaging>
+
+    <properties>
+        <core.version>0.2.0-SNAPSHOT</core.version>
+        <feature.version>0.2.0-SNAPSHOT</feature.version>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+    </properties>
+
+    <modules>
+        <module>CheckpointActor</module>
+    </modules>
+
+    <repositories>
+        <repository>
+            <id>archiva.smartactors-modules</id>
+            <url>http://archiva.smart-tools.info/repository/smartactors-modules/</url>
+        </repository>
+    </repositories>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.5.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.19.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <inherited>false</inherited>
+                <configuration>
+                    <descriptor>bin.xml</descriptor>
+                    <finalName>${artifactId}-${pom.version}</finalName>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <version>2.8.2</version>
+                <goals>
+                    <goal>deploy-file</goal>
+                </goals>
+                <configuration>
+                    <generatePom>false</generatePom>
+                    <file>${basedir}/target/${artifactId}-${feature.version}-archive.zip</file>
+                    <url>http://archiva.smart-tools.info/repository/smartactors-features/</url>
+                    <repositoryId>archiva.smartactors-features</repositoryId>
+
+                    <groupId>info.smart_tools.smartactors</groupId>
+                    <artifactId>${artifactId}</artifactId>
+                    <version>${feature.version}</version>
+                    <packaging>zip</packaging>
+                    <description>The artifact contains follow list of modules: </description>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <distributionManagement>
+        <repository>
+            <id>archiva.smartactors-modules</id>
+            <url>http://archiva.smart-tools.info/repository/smartactors-modules/</url>
+        </repository>
+    </distributionManagement>
+
+</project>


### PR DESCRIPTION
Added stub checkpoint features.
#1. Actor configuration

There should be one checkpoint actor configured for a server (no matter how many checkpoints present in application). The checkpoint actor description (in `"objects"` section) should look like the following:

``` JavaScript
{
  "name": "checkpoint", // Reserved name for checkpoint actor
  "kind": "stateless_actor",
  "dependency": "checkpoint actor",
  // Dependencies of connection options and connection pool 
  "connectionOptionsDependency": ". . .",
  "connectionPoolDependency": ". . .",
  // Name o collection to use to store messages
  "collectionName": ". . ."
}
```
#2. Checkpoint creation

The checkpoint may be added in the end of a receiver chain by adding the `"checkpoint"` section to it's definition:

``` JavaScript
{
  "maps": [
    {
      "id": "myChain",
      "steps": [
        {...}
      ],
      ...,
      "checkpoint": {
        "id": "myCheckpoint1",  // Unique identifier of this checkpoint
        "scheduling": {
          "strategy": "checkpoint repeat strategy",  // Name of scheduling strategy used to determine
                                                                           // when to re-send a message (see pt.3)
          ...
        },
        "recover": {
          "strategy": "single chain recover strategy", // Strategy determining what chain to use when
                                                                              // re-sending a message (see pt.4)
          ...
        }
      }
    }
  ]
}
```

The checkpoint is **always** implicitly placed **in the end** of a chain. There may be only **one checkpoint per chain**.
#3. Scheduling strategies

There are two strategies available:
- `"checkpoint repeat strategy"` -- re-send message fixed amount of times with fixed intervals:

``` JavaScript
{
  "strategy": "checkpoint repeat strategy",
  "interval": "PT3H", //Interval in ISO-8601 format
  "times": 3 // How many times to re-send the message
}
```
- `"checkpoint fibonacci repeat strategy"` -- re-send message with intervals proportional to Fibonacci numbers:

``` JavaScript
{
  "strategy": "checkpoint fibonacci repeat strategy",
  "baseInterval": "PT30M", // Interal that will be multiplied by the next number of Fibonacci
                                          // sequence every time
  "times": 4 // How many times to re-send the message
}
```
#4. Recovery strategies

There are two strategies available:
- `"single chain recover strategy"` -- re-send message to the same chain every time:

``` JavaScript
{
  "strategy": "single chain recover strategy",
  "chain": "recoveryChain" // Name of the chain where the message will be sent
}
```
- `"chain sequence recover strategy"` -- re-send message to (probably) different chains every time:

``` JavaScript
{
  "strategy": "chain sequence recover strategy",
  "trials": [1,2,1,3],                          // Number of re-send trials to switch to next chain after
  "chains": ["A", "B", "C", "D", "E"]  // Names of chains to use

  // In this example the message will be re-sent to chain "A" once then two times to chain "B" then
  // once to "C" then 3 times to "D" and then to "E" all remaining times (of course the message will not
  // be re-sent if the next checkpoint notifies this one)
}
```
#5. PS

The stub implementation _does not_ check correctness of most parameters so be careful.
