### PR TITLE
Added separate exception that throws when document not found by ID

### DIFF
--- a/CoreFeatures/Database-postgresql/PostgresGetByIdTask/src/main/java/info/smart_tools/smartactors/database_postgresql/postgres_getbyid_task/DocumentNotFoundException.java
+++ b/CoreFeatures/Database-postgresql/PostgresGetByIdTask/src/main/java/info/smart_tools/smartactors/database_postgresql/postgres_getbyid_task/DocumentNotFoundException.java
@@ -1,0 +1,25 @@
+package info.smart_tools.smartactors.database_postgresql.postgres_getbyid_task;
+
+/**
+ * Exception used by {@link PostgresGetByIdTask} task document not found by specified ID.
+ */
+public class DocumentNotFoundException extends Exception {
+    /**
+     * Class constructor with exception message.
+     *
+     * @param message exception message
+     */
+    public DocumentNotFoundException(final String message) {
+        super(message);
+    }
+
+    /**
+     * Class constructor with exception message and cause.
+     *
+     * @param message exception message
+     * @param cause   exception cause
+     */
+    public DocumentNotFoundException(final String message, final Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/OldModules/src/site/markdown/tutorials/DBCollectionExample.md
+++ b/OldModules/src/site/markdown/tutorials/DBCollectionExample.md
@@ -145,7 +145,7 @@ Additional parameters:
 - id — unique identifier of the document in the collection
 - callback — lambda of type `IAction<IObject>` which receives the document got by id
 
-If the document with such id does not exist, the `TaskExecutionException` is thrown.
+If the document with such id does not exist, the `TaskExecutionException` is thrown with `DocumentNotFoundException` cause.
 
 #### Example
 


### PR DESCRIPTION
In current version if `PostgresGetByIdTask` not found document by ID, it throws same exception that can be thrown after some database troubles. I added `DocumentNotFoundException` as cause for `TaskExecutionException`. I think that this cause can help to recognize was it database failure or just database haven't document with taken ID.