### PR TITLE
Task/add spaces to postgres regexp

### DIFF
--- a/CoreFeatures/Database-postgresql/Database-postgresqlDistribution/pom.xml
+++ b/CoreFeatures/Database-postgresql/Database-postgresqlDistribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql-distribution</artifactId>
     <packaging>pom</packaging>

--- a/CoreFeatures/Database-postgresql/PostgresAddIndexesTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresAddIndexesTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-add-indexes-task</artifactId>
     <version>0.6.2</version>

--- a/CoreFeatures/Database-postgresql/PostgresConnection/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresConnection/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-connection</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresCountTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresCountTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-count-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresCreateCollectionTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresCreateCollectionTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-create-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresDeleteTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresDeleteTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-delete-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresDropIndexesTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresDropIndexesTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-drop-indexes-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresGetByIdTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresGetByIdTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-getbyid-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresInsertTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresInsertTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-insert-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/PostgresSchema/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresSchema/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-schema</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/Database-postgresql/PostgresSchema/src/main/java/info/smart_tools/smartactors/database_postgresql/postgres_schema/search/FieldPath.java
+++ b/CoreFeatures/Database-postgresql/PostgresSchema/src/main/java/info/smart_tools/smartactors/database_postgresql/postgres_schema/search/FieldPath.java
@@ -14,7 +14,7 @@ public interface FieldPath {
      * Valid path matches this pattern.
      */
     Pattern VALIDATION_PATTERN =
-            Pattern.compile("^([a-zA-Z_а-яА-Я\\-][a-zA-Z0-9_а-яА-Я\\-]*)((\\.([a-zA-Z_а-яА-Я\\-][a-zA-Z0-9_а-яА-Я\\-]*))|(\\[[0-9]+\\]))*$");
+            Pattern.compile("^([a-zA-Z_а-яА-Я \\-][a-zA-Z0-9_а-яА-Я \\-]*)((\\.([a-zA-Z_а-яА-Я \\-][a-zA-Z0-9_а-яА-Я \\-]*))|(\\[[0-9]+\\]))*$");
 
     /**
      * The path is split to the parts using this pattern.

--- a/CoreFeatures/Database-postgresql/PostgresSearchTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresSearchTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-search-task</artifactId>
     <version>0.6.2</version>

--- a/CoreFeatures/Database-postgresql/PostgresUpsertTask/pom.xml
+++ b/CoreFeatures/Database-postgresql/PostgresUpsertTask/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>database-postgresql</artifactId>
-        <version>0.6.2</version>
+        <version>0.6.3</version>
     </parent>
     <artifactId>database-postgresql.postgres-upsert-task</artifactId>
     <version>0.6.1</version>

--- a/CoreFeatures/Database-postgresql/pom.xml
+++ b/CoreFeatures/Database-postgresql/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>info.smart_tools.smartactors</groupId>
     <artifactId>database-postgresql</artifactId>
-    <version>0.6.2</version>
+    <version>0.6.3</version>
     <packaging>pom</packaging>
     <modules>
         <module>PostgresCountTask</module>


### PR DESCRIPTION
Added spaces to the regexp to make possible use fields with spaces in querries. Ex: "a.b c.d"