### PR TITLE
Bugfix/http request maker content length and query

### DIFF
--- a/CoreFeatures/HttpEndpoint/ChannelHandlerNetty/pom.xml
+++ b/CoreFeatures/HttpEndpoint/ChannelHandlerNetty/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.channel-handler-netty</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/CompletableNettyFuture/pom.xml
+++ b/CoreFeatures/HttpEndpoint/CompletableNettyFuture/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.completable-netty-future</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>junit</groupId>

--- a/CoreFeatures/HttpEndpoint/CookiesSetter/pom.xml
+++ b/CoreFeatures/HttpEndpoint/CookiesSetter/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.cookies-setter</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/DeserializeStrategyGet/pom.xml
+++ b/CoreFeatures/HttpEndpoint/DeserializeStrategyGet/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.deserialize-strategy-get</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/DeserializeStrategyPostFormUrlencoded/pom.xml
+++ b/CoreFeatures/HttpEndpoint/DeserializeStrategyPostFormUrlencoded/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.deserialize-strategy-post-form-urlencoded</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/DeserializeStrategyPostJson/pom.xml
+++ b/CoreFeatures/HttpEndpoint/DeserializeStrategyPostJson/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.deserialize-strategy-post-json</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/DeserializeStrategyPostMultipartFormData/pom.xml
+++ b/CoreFeatures/HttpEndpoint/DeserializeStrategyPostMultipartFormData/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.deserialize-strategy-post-multipart-form-data</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/EnvironmentHandler/pom.xml
+++ b/CoreFeatures/HttpEndpoint/EnvironmentHandler/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.environment-handler</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/GetCookieFromRequestRule/pom.xml
+++ b/CoreFeatures/HttpEndpoint/GetCookieFromRequestRule/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.strategy.get-cookie-from-request</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/GetHeaderFromRequestRule/pom.xml
+++ b/CoreFeatures/HttpEndpoint/GetHeaderFromRequestRule/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.strategy.get-header-from-request</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/GetQueryParameterRule/pom.xml
+++ b/CoreFeatures/HttpEndpoint/GetQueryParameterRule/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.strategy.get-query-parameter</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpClient/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpClient/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-client</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpClientHandler/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpClientHandler/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-client-handler</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpClientInitializer/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpClientInitializer/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-client-initializer</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpEndpoint/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpEndpoint/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-endpoint</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpEndpointDistribution/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpEndpointDistribution/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint-distribution</artifactId>
     <packaging>pom</packaging>

--- a/CoreFeatures/HttpEndpoint/HttpHeadersSetter/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpHeadersSetter/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-headers-setter</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpRequestHandler/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpRequestHandler/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-request-handler</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpRequestMaker/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpRequestMaker/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-request-maker</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/main/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMaker.java
+++ b/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/main/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMaker.java
@@ -353,6 +353,11 @@ public class HttpRequestMaker implements IRequestMaker<FullHttpRequest> {
                         HttpHeaderNames.CONTENT_TYPE,
                         "application/json"
                 );
+            } else {
+                httpRequest.headers().set(
+                        HttpHeaderNames.CONTENT_LENGTH,
+                        0
+                );
             }
             httpRequest.headers().set(
                     HttpHeaderNames.HOST,

--- a/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/main/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMaker.java
+++ b/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/main/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMaker.java
@@ -322,7 +322,7 @@ public class HttpRequestMaker implements IRequestMaker<FullHttpRequest> {
     ) throws RequestMakerException {
         try {
             FullHttpRequest httpRequest;
-            String path = url.getPath();
+            String path = url.getFile();
 
             if (content == null){
                 httpRequest = new DefaultFullHttpRequest(

--- a/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/test/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMakerTest.java
+++ b/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/test/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMakerTest.java
@@ -137,7 +137,7 @@ public class HttpRequestMakerTest {
 
         assertEquals(
                 "Invalid request URI",
-                EMPTY_PATH,
+                this.uri.toURL().getFile(),
                 httpRequest.uri()
         );
 
@@ -229,7 +229,7 @@ public class HttpRequestMakerTest {
 
         assertEquals(
                 "Invalid request URI",
-                EMPTY_PATH,
+                this.uri.toURL().getFile(),
                 httpRequest.uri()
         );
 
@@ -282,7 +282,7 @@ public class HttpRequestMakerTest {
 
         assertEquals(
                 "Invalid request URI",
-                EMPTY_PATH,
+                this.uri.toURL().getFile(),
                 httpRequest.uri()
         );
 
@@ -335,7 +335,7 @@ public class HttpRequestMakerTest {
 
         assertEquals(
                 "Invalid request URI",
-                EMPTY_PATH,
+                this.uri.toURL().getFile(),
                 httpRequest.uri()
         );
 

--- a/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/test/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMakerTest.java
+++ b/CoreFeatures/HttpEndpoint/HttpRequestMaker/src/test/java/info/smart_tools/smartactors/http_endpoint/http_request_maker/HttpRequestMakerTest.java
@@ -235,6 +235,7 @@ public class HttpRequestMakerTest {
 
         List<IObject> expectedHeaders = new ArrayList<>(requestHeaders);
         expectedHeaders.addAll(this.getRequiredCommonHeaders());
+        expectedHeaders.add(createKeyValue(HttpHeaderNames.CONTENT_LENGTH.toString(), 0));
 
         for (IObject header: expectedHeaders) {
             String expectedValue = header.getValue(valueFN).toString();

--- a/CoreFeatures/HttpEndpoint/HttpRequestSenderActor/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpRequestSenderActor/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-request-sender-actor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpResponseDeserializationStrategy/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpResponseDeserializationStrategy/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-response-deserialization-strategy</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpResponseHandler/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpResponseHandler/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-response-handler</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpResponseSender/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpResponseSender/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-response-sender</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/HttpServer/pom.xml
+++ b/CoreFeatures/HttpEndpoint/HttpServer/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.http-server</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/ICookiesSetter/pom.xml
+++ b/CoreFeatures/HttpEndpoint/ICookiesSetter/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.interfaces.icookies-extractor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/IHeadersExtractor/pom.xml
+++ b/CoreFeatures/HttpEndpoint/IHeadersExtractor/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.interfaces.iheaders-extractor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/IResponseStatusExtractor/pom.xml
+++ b/CoreFeatures/HttpEndpoint/IResponseStatusExtractor/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.interfaces.iresponse-status-extractor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/MessageToBytesMapper/pom.xml
+++ b/CoreFeatures/HttpEndpoint/MessageToBytesMapper/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.message-to-bytes-mapper</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/NettyClient/pom.xml
+++ b/CoreFeatures/HttpEndpoint/NettyClient/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.netty-client</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>io.netty</groupId>

--- a/CoreFeatures/HttpEndpoint/NettyServer/pom.xml
+++ b/CoreFeatures/HttpEndpoint/NettyServer/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.netty-server</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/PluginHttpRequestSenderActor/pom.xml
+++ b/CoreFeatures/HttpEndpoint/PluginHttpRequestSenderActor/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.plugin-http-request-sender-actor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/ResponseContentJsonStrategy/pom.xml
+++ b/CoreFeatures/HttpEndpoint/ResponseContentJsonStrategy/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.response-content-json-strategy</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/ResponseStatusExtractor/pom.xml
+++ b/CoreFeatures/HttpEndpoint/ResponseStatusExtractor/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.response-status-extractor</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/TcpServer/pom.xml
+++ b/CoreFeatures/HttpEndpoint/TcpServer/pom.xml
@@ -5,10 +5,10 @@
     <parent>
         <groupId>info.smart_tools.smartactors</groupId>
         <artifactId>http-endpoint</artifactId>
-        <version>0.6.3</version>
+        <version>0.6.4</version>
     </parent>
     <artifactId>http-endpoint.tcp-server</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <dependencies>
         <dependency>
             <groupId>info.smart_tools.smartactors</groupId>

--- a/CoreFeatures/HttpEndpoint/pom.xml
+++ b/CoreFeatures/HttpEndpoint/pom.xml
@@ -9,7 +9,7 @@
     </parent>
     <groupId>info.smart_tools.smartactors</groupId>
     <artifactId>http-endpoint</artifactId>
-    <version>0.6.3</version>
+    <version>0.6.4</version>
     <packaging>pom</packaging>
     <modules>
         <module>GetHeaderFromRequestRule</module>


### PR DESCRIPTION
Added `Content-Length: 0` to requests without content as I've faced problems with querying google's API without this header.

Replaced `url.getPath()` with `url.getFile()` because the query parameters were dropped while making POST requests for some reason.

Tested GET and POST requests with query parameters without body and POST with body.